### PR TITLE
chore: upgrade dependencies and unpin transformers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "hydra-core>=1.3.2",
     "simple-lama-inpainting>=0.1.1",
     "datasets>=2.14.4",
-    "transformers==4.55.4",
+    "transformers>=4.55.4",
     "einops>=0.8.0",
     "timm>=1.0.12",
     "kornia>=0.5.0",


### PR DESCRIPTION
## Summary

Upgrades project dependencies and unpins transformers to support versions 4.56+.

## Changes

### Dependency Upgrades
- **transformers**: `==4.55.4` → `>=4.55.4` (now supports 4.57.3)
- **tokenizers**: `0.21.4` → `0.22.1`
- **opencv-python**: `4.11.0.86` → `4.12.0.88`
- **huggingface-hub**: `0.36.0` → `1.2.3`
- **fsspec**: `2025.10.0` → `2025.12.0`
- **antlr4-python3-runtime**: `4.9.3` → `4.13.2`

## Background

Transformers was previously pinned to `==4.55.4` because version 4.56+ introduced a breaking change that required the `is_encoder_decoder` attribute in config classes. The BiRefNet model's Config classes on HuggingFace have now been updated to include this attribute, enabling compatibility with newer transformers versions.

## Testing

✅ All tests pass with transformers 4.57.3:
```
tests/test_basic_decompose.py::test_decompose[False-False] PASSED
tests/test_basic_decompose.py::test_decompose[False-True] PASSED
tests/test_basic_decompose.py::test_decompose[True-False] PASSED
tests/test_basic_decompose.py::test_decompose[True-True] PASSED

4 passed in 112.75s
```

✅ Model loading verified from main branch:
- BiRefNet loads successfully with transformers 4.57.3
- Config has required `is_encoder_decoder` attribute

## Related Issues

Fixes #16

## Benefits

- Access to latest transformers features (continuous batching, new models, bug fixes)
- Updated dependencies with security patches and improvements
- No longer blocked on transformers version updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)