### PR TITLE
feat: Phase 2 OSS migration - Export, Postprocess, Classification, Pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     "kornia>=0.5.0",           # Required by BiRefNet model
     "pillow>=9.5.0",
     "fsspec>=2021.10.0",       # Filesystem abstraction for cloud storage support
+    "psd-tools>=1.9.0",        # PSD export support
+    "pydantic>=2.5.2",         # Pipeline result models for API compatibility
 ]
 
 [project.scripts]

--- a/src/layerd/__init__.py
+++ b/src/layerd/__init__.py
@@ -1,6 +1,24 @@
 """LayerD: Decomposing Raster Graphic Designs into Layers."""
 
+from layerd.classification import ElementLabeler, EntropyLabeler, GradientAwareLabeler
+from layerd.export import PSDBuilder, SVGBuilder, SVGParser, build_exporter
 from layerd.models.layerd import LayerD
+from layerd.pipeline import LayerDPipeline, PipelineResult
+from layerd.postprocess import LayerOrganizer
 from layerd.types import BoundingBox, Element
 
-__all__ = ["LayerD", "BoundingBox", "Element"]
+__all__ = [
+    "LayerD",
+    "LayerDPipeline",
+    "PipelineResult",
+    "BoundingBox",
+    "Element",
+    "SVGBuilder",
+    "SVGParser",
+    "PSDBuilder",
+    "build_exporter",
+    "LayerOrganizer",
+    "ElementLabeler",
+    "EntropyLabeler",
+    "GradientAwareLabeler",
+]

--- a/src/layerd/classification/__init__.py
+++ b/src/layerd/classification/__init__.py
@@ -1,0 +1,19 @@
+"""Element classification module for LayerD.
+
+Provides classifiers for distinguishing between element types:
+- Vector graphics (simple shapes with low complexity)
+- Raster images (photos, complex artwork)
+- Text (from OCR integration)
+"""
+
+from layerd.classification.base import ElementLabeler
+from layerd.classification.entropy import EntropyLabeler
+from layerd.classification.gradient import GradientAwareLabeler
+from layerd.classification.utils import compute_entropy
+
+__all__ = [
+    "ElementLabeler",
+    "EntropyLabeler",
+    "GradientAwareLabeler",
+    "compute_entropy",
+]

--- a/src/layerd/classification/base.py
+++ b/src/layerd/classification/base.py
@@ -1,0 +1,31 @@
+"""Base class for element classification strategies."""
+
+from abc import ABC, abstractmethod
+
+from layerd.types import Element
+
+
+class ElementLabeler(ABC):
+    """Base class for element classification strategies.
+
+    Provides a pluggable architecture for classifying elements by type.
+    Subclasses implement specific classification logic (entropy, gradient, etc.).
+
+    Example:
+        >>> class MyLabeler(ElementLabeler):
+        ...     def classify(self, elements):
+        ...         # Custom classification logic
+        ...         return elements
+    """
+
+    @abstractmethod
+    def classify(self, elements: list[Element]) -> list[Element]:
+        """Classify elements by modifying their 'type' field.
+
+        Args:
+            elements: List of elements to classify
+
+        Returns:
+            List of elements with updated 'type' fields
+        """
+        raise NotImplementedError

--- a/src/layerd/classification/entropy.py
+++ b/src/layerd/classification/entropy.py
@@ -1,0 +1,56 @@
+"""Entropy-based element classification."""
+
+from layerd.types import Element
+
+from .base import ElementLabeler
+from .utils import compute_entropy
+
+
+class EntropyLabeler(ElementLabeler):
+    """Entropy-based classification for vector/image elements.
+
+    Uses Shannon entropy to distinguish between vector graphics (low entropy)
+    and raster images (high entropy). Works well for simple shapes vs photos.
+
+    Args:
+        threshold: Entropy threshold (below = vector, above = image). Default: 5.0
+
+    Example:
+        >>> from layerd.classification import EntropyLabeler
+        >>> labeler = EntropyLabeler(threshold=5.0)
+        >>> classified_elements = labeler.classify(elements)
+        >>>
+        >>> # Check classification results
+        >>> for elem in classified_elements:
+        ...     print(f"Element {elem['id']}: {elem['type']}")
+    """
+
+    def __init__(self, threshold: float = 5.0):
+        """Initialize EntropyLabeler.
+
+        Args:
+            threshold: Entropy threshold for vector/image separation
+        """
+        self.threshold = threshold
+
+    def classify(self, elements: list[Element]) -> list[Element]:
+        """Classify image elements as vector or image based on entropy.
+
+        Text elements are left unchanged. Image elements are classified
+        based on their entropy: low entropy → vector, high entropy → image.
+
+        Args:
+            elements: List of Element dicts
+
+        Returns:
+            List of Element dicts with updated type field
+        """
+        result: list[Element] = []
+        for elem in elements:
+            new_type = elem["type"]
+            if elem["type"] == "image":
+                entropy = compute_entropy(elem["image"])
+                if entropy < self.threshold:
+                    new_type = "vector"
+            result.append(Element(id=elem["id"], type=new_type, image=elem["image"], box=elem["box"]))
+        return result

--- a/src/layerd/classification/gradient.py
+++ b/src/layerd/classification/gradient.py
@@ -1,0 +1,107 @@
+"""Gradient-aware element classification."""
+
+import numpy as np
+from PIL import Image
+
+from layerd.types import Element
+
+from .base import ElementLabeler
+from .utils import compute_entropy
+
+
+class GradientAwareLabeler(ElementLabeler):
+    """Classifier that detects gradients and handles them appropriately.
+
+    Addresses the limitation of pure entropy-based classification which can
+    misclassify gradients. Gradients have low entropy but should remain as
+    raster images since they can't be easily vectorized.
+
+    Args:
+        entropy_threshold: Entropy threshold for vector/image classification (default: 5.0)
+        gradient_threshold: Pixel difference threshold for gradient detection (default: 0.3)
+                          Higher values = less sensitive to gradients
+
+    Example:
+        >>> from layerd.classification import GradientAwareLabeler
+        >>> labeler = GradientAwareLabeler(
+        ...     entropy_threshold=5.0,
+        ...     gradient_threshold=0.3
+        ... )
+        >>> classified_elements = labeler.classify(elements)
+    """
+
+    def __init__(
+        self,
+        entropy_threshold: float = 5.0,
+        gradient_threshold: float = 0.3,
+    ):
+        """Initialize GradientAwareLabeler.
+
+        Args:
+            entropy_threshold: Entropy threshold for vector/image classification
+            gradient_threshold: Average pixel difference threshold for gradient detection.
+                              Mean absolute difference between adjacent pixels (0-255 scale).
+                              Typical range: 0.1-1.0
+        """
+        self.entropy_threshold = entropy_threshold
+        self.gradient_threshold = gradient_threshold
+
+    def classify(self, elements: list[Element]) -> list[Element]:
+        """Classify elements with gradient detection.
+
+        Classification logic:
+        1. Text elements → unchanged
+        2. If gradient detected → keep as "image" (raster)
+        3. Else if low entropy → "vector"
+        4. Else → "image"
+
+        Args:
+            elements: List of Element dicts
+
+        Returns:
+            List of Element dicts with updated type field
+        """
+        result: list[Element] = []
+        for elem in elements:
+            new_type = elem["type"]
+            if elem["type"] == "image":
+                image = elem["image"]
+
+                # Gradient detection first (overrides entropy)
+                if self._has_gradient(image):
+                    new_type = "image"  # Keep as raster
+                elif compute_entropy(image) < self.entropy_threshold:
+                    new_type = "vector"
+                else:
+                    new_type = "image"
+
+            result.append(Element(id=elem["id"], type=new_type, image=elem["image"], box=elem["box"]))
+        return result
+
+    def _has_gradient(self, image: Image.Image) -> bool:
+        """Detect smooth gradients using pixel difference analysis.
+
+        Gradients exhibit consistent but non-zero color changes between
+        adjacent pixels. This heuristic checks for that pattern.
+
+        Args:
+            image: PIL Image (RGBA)
+
+        Returns:
+            True if gradient detected, False otherwise
+        """
+        arr = np.array(image.convert("RGB"))
+
+        # Check minimum size
+        h, w = arr.shape[:2]
+        if h < 10 or w < 10:
+            return False
+
+        # Sample horizontal and vertical gradients
+        h_grad = np.abs(np.diff(arr, axis=1)).mean()
+        v_grad = np.abs(np.diff(arr, axis=0)).mean()
+
+        # Average gradient strength
+        avg_grad = (h_grad + v_grad) / 2
+
+        return avg_grad > self.gradient_threshold

--- a/src/layerd/classification/utils.py
+++ b/src/layerd/classification/utils.py
@@ -1,0 +1,56 @@
+"""Utility functions for element classification."""
+
+import numpy as np
+from PIL import Image
+
+
+def compute_entropy(image: Image.Image) -> float:
+    """Compute alpha-weighted Shannon entropy of image pixel distribution.
+
+    Higher entropy indicates more complex/photographic content.
+    Lower entropy indicates simpler/vector-like content.
+
+    Args:
+        image: PIL Image (RGBA)
+
+    Returns:
+        Entropy value (higher = more complex, lower = simpler)
+
+    Example:
+        >>> from PIL import Image
+        >>> from layerd.classification.utils import compute_entropy
+        >>> image = Image.open("design_element.png")
+        >>> entropy = compute_entropy(image)
+        >>> if entropy < 5.0:
+        ...     print("Likely vector graphics")
+        ... else:
+        ...     print("Likely raster image")
+    """
+    arr = np.array(image.convert("RGBA"))
+    alpha = arr[:, :, 3].flatten().astype(np.float64) / 255.0
+    rgb = arr[:, :, :3].reshape(-1, 3)
+
+    # Skip if no visible pixels
+    if alpha.sum() < 1e-6:
+        return 0.0
+
+    # Quantize colors (256 -> 32 levels per channel)
+    quantized = (rgb // 8).astype(np.uint32)
+    color_indices = quantized[:, 0] * 1024 + quantized[:, 1] * 32 + quantized[:, 2]
+
+    # Alpha-weighted histogram
+    unique_colors, inverse = np.unique(color_indices, return_inverse=True)
+    weights = np.zeros(len(unique_colors), dtype=np.float64)
+    np.add.at(weights, inverse, alpha)
+
+    # Normalize to probabilities
+    total_weight = weights.sum()
+    if total_weight < 1e-6:
+        return 0.0
+    probs = weights / total_weight
+
+    # Shannon entropy
+    probs = probs[probs > 0]
+    entropy = -np.sum(probs * np.log2(probs))
+
+    return float(entropy)

--- a/src/layerd/export/__init__.py
+++ b/src/layerd/export/__init__.py
@@ -1,0 +1,78 @@
+"""Export module for LayerD elements to various formats."""
+
+from typing import Any, Literal, overload
+
+from .base import BaseExporter
+from .psd import PSDBuilder
+from .svg import SVGBuilder, SVGParser
+
+# Lazy registry
+_EXPORTER_REGISTRY: dict[str, type[BaseExporter[Any]]] = {}
+
+
+def _populate_registry() -> None:
+    """Populate exporter registry with available formats."""
+    if not _EXPORTER_REGISTRY:
+        _EXPORTER_REGISTRY["svg"] = SVGBuilder
+        _EXPORTER_REGISTRY["psd"] = PSDBuilder
+
+
+@overload
+def build_exporter(format_type: Literal["svg"] = "svg", **kwargs: Any) -> BaseExporter[str]: ...
+
+
+@overload
+def build_exporter(format_type: Literal["psd"], **kwargs: Any) -> BaseExporter[bytes]: ...
+
+
+def build_exporter(format_type: Literal["svg", "psd"] = "svg", **kwargs: Any) -> BaseExporter[Any]:
+    """Build format exporter.
+
+    Factory function following LayerD's pattern (build_matting, build_ocr).
+
+    Args:
+        format_type: Export format ("svg", "psd")
+        **kwargs: Format-specific configuration
+
+    Returns:
+        Initialized exporter
+
+    Raises:
+        ValueError: If format not available
+
+    Examples:
+        >>> # SVG with base64 images
+        >>> exporter = build_exporter("svg")
+        >>> svg = exporter(elements, canvas_size)
+        >>>
+        >>> # SVG with external images
+        >>> exporter = build_exporter("svg", image_mode="external", image_dir="./images")
+        >>> svg = exporter(elements, canvas_size)
+        >>>
+        >>> # PSD export
+        >>> exporter = build_exporter("psd")
+        >>> psd_bytes = exporter(elements, canvas_size)
+    """
+    # Lazy load registry
+    _populate_registry()
+
+    if format_type not in _EXPORTER_REGISTRY:
+        available = list(_EXPORTER_REGISTRY.keys())
+        error_msg = f"Format '{format_type}' not available."
+
+        if available:
+            error_msg += f" Available formats: {available}."
+
+        raise ValueError(error_msg)
+
+    exporter_cls = _EXPORTER_REGISTRY[format_type]
+    return exporter_cls(**kwargs)
+
+
+__all__ = [
+    "BaseExporter",
+    "SVGBuilder",
+    "SVGParser",
+    "PSDBuilder",
+    "build_exporter",
+]

--- a/src/layerd/export/base.py
+++ b/src/layerd/export/base.py
@@ -1,0 +1,66 @@
+"""Base class for format exporters."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Generic, TypeVar
+
+from layerd.types import Element
+
+# Type variable for output format (str for SVG, bytes for PSD)
+OutputT = TypeVar("OutputT", str, bytes)
+
+
+class BaseExporter(ABC, Generic[OutputT]):
+    """Abstract base class for layer export formats.
+
+    Follows the ElementLabeler pattern with strategy-based configuration.
+    Subclasses implement specific format export logic (SVG, PSD, etc.).
+
+    Type Parameters:
+        OutputT: Output format type (str for text formats, bytes for binary)
+
+    Example:
+        >>> class SVGBuilder(BaseExporter[str]):
+        ...     def export(self, elements, canvas_size):
+        ...         return "<svg>...</svg>"
+    """
+
+    def __init__(self, **config: Any) -> None:
+        """Initialize exporter with format-specific configuration.
+
+        The base implementation accepts configuration options but does not use them,
+        allowing subclasses flexibility in their initialization signatures.
+
+        Subclasses should call ``super().__init__()`` before their own initialization
+        to maintain consistency with the base class interface.
+
+        Args:
+            **config: Format-specific configuration options (interpreted by subclasses)
+        """
+        pass
+
+    @abstractmethod
+    def export(self, elements: list[Element], canvas_size: tuple[int, int]) -> OutputT:
+        """Export elements to format-specific representation.
+
+        Args:
+            elements: List of processed elements with images and bounding boxes
+            canvas_size: Canvas dimensions as (width, height)
+
+        Returns:
+            Format-specific output (str for text formats, bytes for binary)
+        """
+        raise NotImplementedError
+
+    def __call__(self, elements: list[Element], canvas_size: tuple[int, int]) -> OutputT:
+        """Convenience method for export.
+
+        Enables: exporter(elements, canvas_size)
+
+        Args:
+            elements: List of processed elements
+            canvas_size: Canvas dimensions
+
+        Returns:
+            Format-specific output
+        """
+        return self.export(elements, canvas_size)

--- a/src/layerd/export/psd.py
+++ b/src/layerd/export/psd.py
@@ -1,0 +1,81 @@
+"""PSD (Photoshop Document) export for LayerD elements."""
+
+from io import BytesIO
+from typing import Literal
+
+from psd_tools import PSDImage
+
+from layerd.types import Element
+
+from .base import BaseExporter
+
+
+class PSDBuilder(BaseExporter[bytes]):
+    """PSD (Photoshop Document) export builder for LayerD elements.
+
+    Exports decomposed layers as Photoshop-compatible PSD file format.
+    Each element becomes a separate layer with metadata preserved.
+
+    Args:
+        color_depth: Bit depth per channel (8, 16, or 32)
+        compression: Compression type for layer data ("rle", "zip", or "raw")
+
+    Example:
+        >>> builder = PSDBuilder()
+        >>> psd_bytes = builder(elements, canvas_size)
+        >>> with open("output.psd", "wb") as f:
+        ...     f.write(psd_bytes)
+    """
+
+    def __init__(self, color_depth: Literal[8, 16, 32] = 8, compression: str = "rle") -> None:
+        """Initialize PSD builder.
+
+        Args:
+            color_depth: Bit depth (8, 16, or 32)
+            compression: Compression method ("rle", "zip", or "raw")
+        """
+        super().__init__()
+        self.color_depth = color_depth
+        self.compression = compression
+
+    def export(self, elements: list[Element], canvas_size: tuple[int, int]) -> bytes:
+        """Export elements to PSD bytes.
+
+        Args:
+            elements: List of processed elements with images and bounding boxes
+            canvas_size: Canvas dimensions (width, height)
+
+        Returns:
+            PSD file as bytes
+        """
+        # Map compression string to psd-tools enum value
+        compression_map = {
+            "raw": 0,  # No compression
+            "rle": 1,  # RLE compression (default, widely supported)
+            "zip": 2,  # ZIP compression
+        }
+        compression_value = compression_map.get(self.compression.lower(), 1)
+
+        # Create new PSD document
+        psd = PSDImage.new(mode="RGBA", size=canvas_size, depth=self.color_depth)
+
+        # Add layers in natural order
+        # Elements are top-to-bottom (element[0] = topmost in visual stacking)
+        # Photoshop renders layers in the same order for correct visual result
+        for element in elements:
+            layer_name = f"{element['type']}_{element['id']:02d}"
+            left = element["box"]["x_min"]
+            top = element["box"]["y_min"]
+
+            # Create pixel layer from element image
+            psd.create_pixel_layer(
+                image=element["image"],  # PIL.Image RGBA
+                name=layer_name,
+                left=left,
+                top=top,
+            )
+
+        # Save to bytes with compression
+        buffer = BytesIO()
+        psd.save(buffer, compression=compression_value)
+        return buffer.getvalue()

--- a/src/layerd/export/svg.py
+++ b/src/layerd/export/svg.py
@@ -1,0 +1,241 @@
+"""SVG export and import for LayerD elements."""
+
+import base64
+import xml.etree.ElementTree as ET
+from io import BytesIO
+from pathlib import Path
+from typing import Literal
+
+from PIL import Image
+
+from layerd.types import BoundingBox, Element
+
+from .base import BaseExporter
+
+
+class SVGBuilder(BaseExporter[str]):
+    """SVG export builder for LayerD elements.
+
+    Supports two image embedding modes:
+    - base64: Embed images as data URIs (default, self-contained)
+    - external: Save images to directory and reference via relative paths
+
+    The builder produces standards-compliant SVG with element metadata
+    stored as data attributes (data-type, data-id) for round-trip conversion.
+
+    Args:
+        image_mode: Image embedding mode ("base64" or "external")
+        image_dir: Directory for external images (required if image_mode="external")
+
+    Example:
+        >>> # Base64 mode (default)
+        >>> builder = SVGBuilder()
+        >>> svg = builder(elements, canvas_size)
+        >>>
+        >>> # External images
+        >>> builder = SVGBuilder(image_mode="external", image_dir="./images")
+        >>> svg = builder(elements, canvas_size)
+    """
+
+    def __init__(self, image_mode: Literal["base64", "external"] = "base64", image_dir: str | None = None) -> None:
+        """Initialize SVG builder.
+
+        Args:
+            image_mode: "base64" for embedded images, "external" for file references
+            image_dir: Directory path for external images (required if image_mode="external")
+
+        Raises:
+            ValueError: If image_mode="external" but image_dir is None
+        """
+        super().__init__()
+        self.image_mode = image_mode
+        self.image_dir = Path(image_dir) if image_dir else None
+
+        if image_mode == "external" and self.image_dir is None:
+            raise ValueError("image_dir must be provided when image_mode='external'")
+
+        # Create directory if needed
+        if self.image_dir is not None:
+            self.image_dir.mkdir(parents=True, exist_ok=True)
+
+    def export(self, elements: list[Element], canvas_size: tuple[int, int]) -> str:
+        """Export elements to SVG string.
+
+        Args:
+            elements: List of processed elements
+            canvas_size: Canvas dimensions (width, height)
+
+        Returns:
+            SVG string with embedded or linked images
+        """
+        width, height = canvas_size
+
+        svg_parts = [
+            f'<svg width="{width}" height="{height}" xmlns="http://www.w3.org/2000/svg">',
+        ]
+
+        for elem in elements:
+            # Get image href based on mode
+            if self.image_mode == "external":
+                href = self._save_element_image(elem)
+            else:
+                href = self._element_to_base64(elem)
+
+            # Get bounding box
+            box = elem["box"]
+            x = box["x_min"]
+            y = box["y_min"]
+            w = box["x_max"] - box["x_min"]
+            h = box["y_max"] - box["y_min"]
+
+            # Create image element with metadata
+            svg_parts.append(
+                f'  <image x="{x}" y="{y}" width="{w}" height="{h}" '
+                f'href="{href}" '
+                f'data-type="{elem["type"]}" '
+                f'data-id="{elem["id"]}" />'
+            )
+
+        svg_parts.append("</svg>")
+        return "\n".join(svg_parts)
+
+    def _element_to_base64(self, element: Element) -> str:
+        """Convert element image to base64 data URI.
+
+        Args:
+            element: Element with PIL Image
+
+        Returns:
+            Data URI string
+        """
+        buffered = BytesIO()
+        element["image"].save(buffered, format="PNG")
+        img_base64 = base64.b64encode(buffered.getvalue()).decode("utf-8")
+        return f"data:image/png;base64,{img_base64}"
+
+    def _save_element_image(self, element: Element) -> str:
+        """Save element image to disk and return relative path.
+
+        Args:
+            element: Element to save
+
+        Returns:
+            Relative path for SVG href attribute
+        """
+        assert self.image_dir is not None  # Validated in __init__
+
+        filename = f"{element['id']}_{element['type']}.png"
+        filepath = self.image_dir / filename
+        element["image"].save(filepath, format="PNG")
+        return f"./{self.image_dir.name}/{filename}"
+
+
+class SVGParser:
+    """SVG parser for converting SVG back to elements.
+
+    Separate from SVGBuilder to follow single responsibility principle.
+    Import/export are asymmetric operations with different concerns.
+
+    Example:
+        >>> parser = SVGParser()
+        >>> elements = parser.parse(svg_content, svg_path="output.svg")
+    """
+
+    def parse(self, svg_content: str, svg_path: str | None = None) -> list[Element]:
+        """Parse SVG string into elements.
+
+        Args:
+            svg_content: SVG string with embedded or linked images
+            svg_path: Path to SVG file (required for external images)
+
+        Returns:
+            List of reconstructed elements
+
+        Raises:
+            ValueError: If external images found but svg_path not provided
+        """
+        # Parse SVG
+        root = ET.fromstring(svg_content)
+
+        # Handle namespace
+        ns = {"svg": "http://www.w3.org/2000/svg"}
+        image_tags = root.findall(".//svg:image", ns)
+        if not image_tags:
+            image_tags = root.findall(".//image")
+
+        elements: list[Element] = []
+
+        for img_tag in image_tags:
+            # Extract attributes
+            x = int(img_tag.get("x", "0"))
+            y = int(img_tag.get("y", "0"))
+            width = int(img_tag.get("width", "0"))
+            height = int(img_tag.get("height", "0"))
+            elem_type = img_tag.get("data-type", "image")
+            elem_id = int(img_tag.get("data-id", "0"))
+
+            # Extract and load image
+            href = img_tag.get("href") or img_tag.get("{http://www.w3.org/1999/xlink}href")
+            assert href is not None, "Image href is required"
+
+            if href.startswith("data:image/png;base64,"):
+                image = self._load_base64_image(href)
+            else:
+                if svg_path is None:
+                    raise ValueError("svg_path required for external image references")
+                image = self._load_external_image(href, svg_path)
+
+            # Create bounding box
+            bbox = BoundingBox(
+                x_min=x,
+                y_min=y,
+                x_max=x + width,
+                y_max=y + height,
+            )
+
+            # Create element
+            elements.append(Element(id=elem_id, type=elem_type, image=image, box=bbox))
+
+        return elements
+
+    def _load_base64_image(self, href: str) -> Image.Image:
+        """Load image from base64 data URI.
+
+        Args:
+            href: Data URI with base64-encoded image
+
+        Returns:
+            PIL Image
+        """
+        base64_data = href.replace("data:image/png;base64,", "")
+        img_bytes = base64.b64decode(base64_data)
+        return Image.open(BytesIO(img_bytes))
+
+    def _load_external_image(self, href: str, svg_path: str) -> Image.Image:
+        """Load image from external file.
+
+        Args:
+            href: Relative path to image file
+            svg_path: Path to SVG file (for resolving relative paths)
+
+        Returns:
+            PIL Image
+        """
+        # Resolve relative path
+        if href.startswith("./"):
+            href = href[2:]
+        svg_path_obj = Path(svg_path)
+        image_path = svg_path_obj.parent / href
+        return Image.open(image_path)
+
+    def __call__(self, svg_content: str, svg_path: str | None = None) -> list[Element]:
+        """Convenience method for parsing.
+
+        Args:
+            svg_content: SVG string
+            svg_path: Path to SVG file
+
+        Returns:
+            List of elements
+        """
+        return self.parse(svg_content, svg_path)

--- a/src/layerd/pipeline.py
+++ b/src/layerd/pipeline.py
@@ -1,0 +1,322 @@
+"""Unified pipeline for end-to-end layer decomposition and export.
+
+This module provides LayerDPipeline, a high-level API that orchestrates:
+1. Layer decomposition (LayerD)
+2. Layer organization (LayerOrganizer)
+3. Element classification (ElementLabeler)
+
+Export functionality (SVG, PSD) is provided through PipelineResult methods.
+
+Example usage:
+    >>> from layerd import LayerDPipeline
+    >>> from PIL import Image
+    >>> pipeline = LayerDPipeline()
+    >>> image = Image.open("design.png")
+    >>> result = pipeline(image)
+    >>> result.save("output.svg")  # Auto-detects format
+    >>> # OR: svg_string = result.to_svg()
+
+Advanced usage with custom labeler:
+    >>> from layerd import GradientAwareLabeler
+    >>> pipeline = LayerDPipeline(
+    ...     labeler=GradientAwareLabeler(entropy_threshold=5.0),
+    ...     device="cuda"
+    ... )
+    >>> result = pipeline(image, max_iterations=3)
+    >>> result.save("output.psd")  # PSD export
+
+The pipeline is designed for future REST API server integration with Pydantic models
+that support JSON serialization.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Literal
+
+from PIL import Image
+from pydantic import BaseModel, ConfigDict
+
+from layerd.classification import ElementLabeler, EntropyLabeler
+from layerd.export import SVGBuilder, build_exporter
+from layerd.models.layerd import LayerD
+from layerd.postprocess import LayerOrganizer
+from layerd.types import Element
+
+logger = logging.getLogger(__name__)
+
+# Sentinel value for "not provided" parameter
+_UNSET = object()
+
+
+class PipelineResult(BaseModel):
+    """Result from LayerDPipeline processing.
+
+    Uses Pydantic for future API server compatibility.
+    Serializable to JSON for REST API responses (with custom serializers for images).
+
+    Attributes:
+        elements: Organized elements with bounding boxes and type classification
+        layers: List of RGBA PIL Images (background + foreground layers)
+        ocr_result: Reserved for future OCR integration (Phase 3)
+        canvas_size: Original image size as (width, height) tuple
+    """
+
+    elements: list[Element]
+    layers: list[Any]  # PIL Images - requires custom serializer for API use
+    ocr_result: dict[str, Any] | None
+    canvas_size: tuple[int, int]
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def to_svg(
+        self,
+        image_mode: Literal["base64", "external"] = "base64",
+        image_dir: str | None = None,
+    ) -> str:
+        """Generate SVG string representation.
+
+        Args:
+            image_mode: "base64" (embedded) or "external" (separate files)
+            image_dir: Directory for external images (required if image_mode="external")
+
+        Returns:
+            SVG string
+
+        Raises:
+            ValueError: If image_mode="external" but image_dir not provided
+
+        Example:
+            >>> result = pipeline(image)
+            >>> svg = result.to_svg()  # Base64 embedded
+            >>> svg = result.to_svg(image_mode="external", image_dir="./images")
+        """
+        if image_mode == "external" and image_dir is None:
+            raise ValueError("image_dir required when image_mode='external'")
+
+        builder = SVGBuilder(image_mode=image_mode, image_dir=image_dir)
+        return builder(self.elements, self.canvas_size)
+
+    def to_psd(
+        self,
+        compression: str = "rle",
+        color_depth: Literal[8, 16, 32] = 8,
+    ) -> bytes:
+        """Generate PSD bytes representation.
+
+        Args:
+            compression: Compression method ("rle" or "zip")
+            color_depth: Bit depth per channel (8, 16, or 32)
+
+        Returns:
+            PSD file as bytes
+
+        Example:
+            >>> result = pipeline(image)
+            >>> psd_bytes = result.to_psd()
+            >>> with open("output.psd", "wb") as f:
+            ...     f.write(psd_bytes)
+        """
+        builder = build_exporter("psd", compression=compression, color_depth=color_depth)
+        return builder(self.elements, self.canvas_size)
+
+    def save(
+        self,
+        path: str,
+        format: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Save result to file.
+
+        Format auto-detected from file extension if not specified.
+
+        Args:
+            path: Output file path
+            format: Export format ("svg" or "psd"), auto-detected if None
+            **kwargs: Format-specific options (passed to to_svg() or to_psd())
+
+        Raises:
+            ValueError: If format cannot be determined or is unsupported
+
+        Examples:
+            >>> result.save("output.svg")  # Auto-detects SVG format
+            >>> result.save("output.psd")  # Auto-detects PSD format
+            >>> result.save("output", format="svg")  # Explicit format
+            >>> result.save("output.svg", image_mode="external", image_dir="./img")
+        """
+        # Auto-detect format from extension
+        if format is None:
+            suffix = Path(path).suffix.lower()
+            if suffix == ".svg":
+                format = "svg"
+            elif suffix == ".psd":
+                format = "psd"
+            else:
+                raise ValueError(
+                    f"Cannot determine format from extension '{suffix}'. "
+                    "Specify format explicitly with format='svg' or format='psd'"
+                )
+
+        # Generate data
+        data: str | bytes
+        mode: str
+        if format == "svg":
+            data = self.to_svg(**kwargs)
+            mode = "w"
+        elif format == "psd":
+            data = self.to_psd(**kwargs)
+            mode = "wb"
+        else:
+            raise ValueError(f"Unsupported format: {format}. Use 'svg' or 'psd'")
+
+        # Save to local file
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        with open(path, mode) as f:
+            f.write(data)
+
+
+class LayerDPipeline:
+    """Unified pipeline for end-to-end layer decomposition and export.
+
+    Orchestrates the complete workflow from image input to export:
+    - Layer decomposition with BiRefNet-based matting
+    - Layer organization with element extraction
+    - Element classification (text vs vector vs image)
+    - Export to SVG or PSD formats
+
+    The pipeline is stateless and thread-safe. Each call processes one image independently.
+
+    Args:
+        matting_hf_card: HuggingFace model card for matting model
+        matting_process_size: Processing size for matting (width, height). None = auto
+        matting_weight_path: Path to custom matting weights. None = use HF card
+        use_unblend: Enable unblending for foreground color estimation
+        bg_refine: Enable background refinement
+        fg_refine: Enable foreground refinement
+        fg_refine_num_colors: Number of colors for foreground refinement
+        bg_refine_num_colors: Number of colors for background refinement
+        kernel_scale: Kernel scale for refinement
+        overlap_threshold: Overlap threshold for element organization
+        labeler: Element classifier (None = disable, default = EntropyLabeler)
+        labeler_threshold: Entropy threshold for default EntropyLabeler
+        device: Device for computation ("cpu" or "cuda")
+
+    Note:
+        Device can be changed after initialization using the .to() method.
+
+    Example:
+        >>> pipeline = LayerDPipeline(device="cuda")
+        >>> result = pipeline(image, max_iterations=3)
+        >>> result.save("output.svg")
+    """
+
+    def __init__(
+        self,
+        # LayerD parameters
+        matting_hf_card: str = "cyberagent/layerd-birefnet",
+        matting_process_size: tuple[int, int] | None = None,
+        matting_weight_path: str | None = None,
+        use_unblend: bool = True,
+        bg_refine: bool = True,
+        fg_refine: bool = True,
+        fg_refine_num_colors: int = 2,
+        bg_refine_num_colors: int = 10,
+        kernel_scale: float = 0.015,
+        # LayerOrganizer parameters
+        overlap_threshold: float = 0.9,
+        labeler: ElementLabeler | None = _UNSET,  # type: ignore[assignment]  # Sentinel for "not provided"
+        labeler_threshold: float = 5.0,
+        # Device
+        device: str = "cpu",
+    ) -> None:
+        """Initialize the pipeline with configuration parameters."""
+        # Initialize LayerD model
+        self.layerd = LayerD(
+            matting_hf_card=matting_hf_card,
+            matting_process_size=matting_process_size,
+            matting_weight_path=matting_weight_path,
+            use_unblend=use_unblend,
+            bg_refine=bg_refine,
+            fg_refine=fg_refine,
+            fg_refine_num_colors=fg_refine_num_colors,
+            bg_refine_num_colors=bg_refine_num_colors,
+            kernel_scale=kernel_scale,
+            device=device,
+        )
+
+        # Store LayerOrganizer parameters
+        self.overlap_threshold = overlap_threshold
+
+        # Store labeler (defaults to EntropyLabeler with specified threshold if not provided)
+        self.labeler: ElementLabeler | None
+        if labeler is _UNSET:
+            self.labeler = EntropyLabeler(threshold=labeler_threshold)
+        else:
+            self.labeler = labeler  # type: ignore[assignment]  # labeler can be _UNSET at runtime
+
+        # Store device
+        self.device = device
+
+    def __call__(
+        self,
+        image: Image.Image,
+        max_iterations: int = 3,
+    ) -> PipelineResult:
+        """Run the complete pipeline on an image.
+
+        Args:
+            image: Input PIL Image (RGB or RGBA)
+            max_iterations: Maximum number of decomposition iterations
+
+        Returns:
+            PipelineResult with elements, layers, and canvas size
+
+        Note:
+            SVG/PSD generation is done via PipelineResult.to_svg()/to_psd()/save()
+
+        Raises:
+            ValueError: If image is invalid or decomposition fails
+            RuntimeError: If a pipeline stage fails unexpectedly
+        """
+        # Step 1: Decompose with LayerD
+        try:
+            layers = self.layerd.decompose(image, max_iterations=max_iterations)
+            canvas_size = image.size  # (width, height)
+        except Exception as e:
+            raise RuntimeError(f"LayerD decomposition failed: {e}") from e
+
+        # Step 2: Organize layers
+        try:
+            organizer = LayerOrganizer(
+                overlap_threshold=self.overlap_threshold,
+                labeler=self.labeler,
+            )
+            # No OCR in Phase 2 - will be added in Phase 3
+            elements = organizer.organize(layers, ocr_result=None)
+            logger.info(f"Organized {len(elements)} elements from {len(layers)} layers")
+        except Exception as e:
+            raise RuntimeError(f"Layer organization failed: {e}") from e
+
+        # Step 3: Return result (SVG/PSD generation moved to PipelineResult methods)
+        return PipelineResult(
+            elements=elements,
+            layers=layers,
+            ocr_result=None,  # Reserved for Phase 3 OCR integration
+            canvas_size=canvas_size,
+        )
+
+    def to(self, device: str) -> "LayerDPipeline":
+        """Move pipeline to specified device.
+
+        Args:
+            device: Target device ("cpu" or "cuda")
+
+        Returns:
+            Self for method chaining
+
+        Example:
+            >>> pipeline = LayerDPipeline(device="cpu")
+            >>> pipeline.to("cuda")  # Move to GPU
+        """
+        self.layerd = self.layerd.to(device)
+        self.device = device
+        return self

--- a/src/layerd/postprocess/__init__.py
+++ b/src/layerd/postprocess/__init__.py
@@ -1,0 +1,5 @@
+"""Postprocessing module for layer organization and classification."""
+
+from layerd.postprocess.organizer import LayerOrganizer
+
+__all__ = ["LayerOrganizer"]

--- a/src/layerd/postprocess/organizer.py
+++ b/src/layerd/postprocess/organizer.py
@@ -1,0 +1,215 @@
+"""Layer organization and element extraction."""
+
+from typing import TYPE_CHECKING, Any
+
+import cv2
+import numpy as np
+from PIL import Image
+
+from layerd.models.helpers import divide_mask_to_connected_components
+from layerd.types import BoundingBox, Element
+from layerd.utils import apply_mask, assign_masks_to_groups, crop_image_with_bbox, mask_to_bbox
+
+if TYPE_CHECKING:
+    # Import for type checking only to avoid circular dependencies
+    from typing import TypedDict
+
+    class Polygon(TypedDict):
+        """Polygon vertex for OCR results."""
+
+        x: int
+        y: int
+
+
+class LayerOrganizer:
+    """Organizer for LayerD decomposition results.
+
+    Processes raw RGBA layers into structured elements with metadata.
+    Supports optional OCR integration for text detection.
+
+    Args:
+        overlap_threshold: Minimum overlap ratio for OCR-CC matching (default: 0.9)
+        labeler: Element classification strategy (optional, from layerd.classification)
+
+    Example:
+        >>> from layerd import LayerD
+        >>> from layerd.postprocess import LayerOrganizer
+        >>> from PIL import Image
+        >>>
+        >>> # Decompose image
+        >>> layerd = LayerD()
+        >>> image = Image.open("design.png")
+        >>> layers = layerd.decompose(image)
+        >>>
+        >>> # Organize into elements (without OCR)
+        >>> organizer = LayerOrganizer()
+        >>> elements = organizer.organize(layers)
+        >>>
+        >>> # Access organized elements
+        >>> for elem in elements:
+        ...     print(f"Element {elem['id']}: type={elem['type']}, bbox={elem['box']}")
+    """
+
+    def __init__(
+        self,
+        overlap_threshold: float = 0.9,
+        labeler: Any | None = None,
+    ) -> None:
+        """Initialize layer organizer.
+
+        Args:
+            overlap_threshold: Minimum overlap ratio for OCR-CC matching
+            labeler: Element classification strategy (None to skip classification)
+                    Should have a classify(elements: list[Element]) -> list[Element] method
+        """
+        self.overlap_threshold = overlap_threshold
+        self.labeler = labeler
+
+    def organize(
+        self,
+        layers: list[Image.Image],
+        ocr_result: dict[str, Any] | None = None,
+    ) -> list[Element]:
+        """Organize LayerD decomposition results into structured elements.
+
+        Args:
+            layers: List of RGBA PIL Images from LayerD decomposition
+            ocr_result: Optional OCR result with format:
+                       {"image_size": (width, height),
+                        "blocks": [{"text": str, "bbox": BoundingBox, ...}, ...]}
+                       If None, all elements are classified as "image" type.
+
+        Returns:
+            List of organized elements with cropped images and bounding boxes
+
+        Example:
+            >>> # Without OCR
+            >>> organizer = LayerOrganizer()
+            >>> elements = organizer.organize(layers)
+            >>>
+            >>> # With OCR (requires layerd-internal or custom OCR)
+            >>> ocr_result = {"image_size": (800, 600), "blocks": [...]}
+            >>> elements = organizer.organize(layers, ocr_result)
+        """
+        assert len(layers) > 0, "At least one layer is required"
+
+        # Determine canvas size
+        if ocr_result is not None:
+            canvas_size = ocr_result["image_size"]
+        else:
+            # Use first layer dimensions as canvas size
+            canvas_size = layers[0].size
+
+        # Pre-compute OCR block masks if OCR result is provided
+        block_masks: list[np.ndarray] = []
+        if ocr_result is not None and "blocks" in ocr_result:
+            ocr_blocks = ocr_result["blocks"]
+            for block in ocr_blocks:
+                # Use polygon if available, otherwise use rectangular bbox
+                if "polygon" in block and block["polygon"]:
+                    block_mask = self._polygon_to_mask(block["polygon"], canvas_size)
+                else:
+                    block_mask = self._bbox_to_mask(block["bbox"], canvas_size)
+                block_masks.append(block_mask)
+
+        elements: list[Element] = []
+        element_id = 0
+
+        for layer in layers:
+            # Get layer alpha mask
+            layer_np = np.array(layer)
+            alpha = layer_np[:, :, 3] if layer_np.shape[2] == 4 else np.ones(layer_np.shape[:2], dtype=np.uint8) * 255
+            layer_mask = alpha > 0
+
+            # Divide into connected components
+            cc_masks = divide_mask_to_connected_components(layer_mask)
+
+            if block_masks:
+                # Assign connected components to OCR blocks
+                block_combined_masks, unassigned_ccs = assign_masks_to_groups(
+                    cc_masks, block_masks, self.overlap_threshold
+                )
+
+                # Create text elements from matched OCR blocks
+                for combined_mask in block_combined_masks:
+                    if np.any(combined_mask > 0):
+                        bbox = mask_to_bbox(combined_mask)
+                        masked = apply_mask(layer, combined_mask)
+                        cropped = crop_image_with_bbox(masked, bbox)
+                        elements.append(Element(id=element_id, type="text", image=cropped, box=bbox))
+                        element_id += 1
+
+                # Create image elements from unassigned CCs
+                for cc_mask in unassigned_ccs:
+                    bbox = mask_to_bbox(cc_mask)
+                    masked = apply_mask(layer, cc_mask)
+                    cropped = crop_image_with_bbox(masked, bbox)
+                    elements.append(Element(id=element_id, type="image", image=cropped, box=bbox))
+                    element_id += 1
+            else:
+                # No OCR - all connected components become "image" elements
+                for cc_mask in cc_masks:
+                    bbox = mask_to_bbox(cc_mask)
+                    masked = apply_mask(layer, cc_mask)
+                    cropped = crop_image_with_bbox(masked, bbox)
+                    elements.append(Element(id=element_id, type="image", image=cropped, box=bbox))
+                    element_id += 1
+
+        # Apply classification if labeler is provided
+        if self.labeler is not None:
+            elements = self.labeler.classify(elements)
+
+        return elements
+
+    def __call__(
+        self,
+        layers: list[Image.Image],
+        ocr_result: dict[str, Any] | None = None,
+    ) -> list[Element]:
+        """Convenience method for organize().
+
+        Args:
+            layers: List of RGBA PIL Images
+            ocr_result: Optional OCR result
+
+        Returns:
+            List of organized elements
+        """
+        return self.organize(layers, ocr_result)
+
+    def _bbox_to_mask(self, bbox: BoundingBox, canvas_size: tuple[int, int]) -> np.ndarray:
+        """Convert rectangular bounding box to binary mask.
+
+        Args:
+            bbox: Bounding box with x_min, y_min, x_max, y_max
+            canvas_size: (width, height) of the canvas
+
+        Returns:
+            Binary mask as uint8 numpy array (H, W)
+        """
+        width, height = canvas_size
+        mask = np.zeros((height, width), dtype=np.uint8)
+        mask[bbox["y_min"] : bbox["y_max"], bbox["x_min"] : bbox["x_max"]] = 255
+        return mask
+
+    def _polygon_to_mask(self, polygon: list[dict[str, int]], canvas_size: tuple[int, int]) -> np.ndarray:
+        """Convert polygon vertices to binary mask.
+
+        Args:
+            polygon: List of vertices with x and y coordinates
+                    Each vertex is a dict with 'x' and 'y' keys
+            canvas_size: (width, height) of the canvas
+
+        Returns:
+            Binary mask as uint8 numpy array (H, W)
+        """
+        width, height = canvas_size
+        mask = np.zeros((height, width), dtype=np.uint8)
+
+        # Convert vertices to numpy array
+        points = np.array([[v["x"], v["y"]] for v in polygon], dtype=np.int32)
+
+        # Fill polygon
+        cv2.fillPoly(mask, [points], (255,))
+
+        return mask

--- a/tests/classification/__init__.py
+++ b/tests/classification/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for classification module."""

--- a/tests/classification/test_classification.py
+++ b/tests/classification/test_classification.py
@@ -1,0 +1,156 @@
+"""Tests for element classification."""
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+from layerd.classification import EntropyLabeler, GradientAwareLabeler, compute_entropy
+from layerd.types import BoundingBox, Element
+
+
+def create_solid_color_element(elem_id: int, size: tuple[int, int], color: tuple[int, int, int, int]) -> Element:
+    """Create element with solid color (low entropy)."""
+    img = Image.new("RGBA", size, color)
+    return Element(
+        id=elem_id, type="image", image=img, box=BoundingBox(x_min=0, y_min=0, x_max=size[0], y_max=size[1])
+    )
+
+
+def create_noise_element(elem_id: int, size: tuple[int, int]) -> Element:
+    """Create element with random noise (high entropy)."""
+    arr = np.random.randint(0, 256, (size[1], size[0], 4), dtype=np.uint8)
+    arr[:, :, 3] = 255  # Full alpha
+    img = Image.fromarray(arr, "RGBA")
+    return Element(
+        id=elem_id, type="image", image=img, box=BoundingBox(x_min=0, y_min=0, x_max=size[0], y_max=size[1])
+    )
+
+
+def create_gradient_element(elem_id: int, size: tuple[int, int]) -> Element:
+    """Create element with gradient (low entropy but should stay as image)."""
+    img = Image.new("RGBA", size, (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+
+    # Create horizontal gradient
+    for x in range(size[0]):
+        color_val = int(255 * x / size[0])
+        draw.line([(x, 0), (x, size[1])], fill=(color_val, color_val, color_val, 255))
+
+    return Element(
+        id=elem_id, type="image", image=img, box=BoundingBox(x_min=0, y_min=0, x_max=size[0], y_max=size[1])
+    )
+
+
+def test_compute_entropy_solid_color() -> None:
+    """Test entropy computation for solid color."""
+    img = Image.new("RGBA", (100, 100), (255, 0, 0, 255))
+    entropy = compute_entropy(img)
+    assert entropy < 1.0, "Solid color should have very low entropy"
+
+
+def test_compute_entropy_noise() -> None:
+    """Test entropy computation for noise."""
+    arr = np.random.randint(0, 256, (100, 100, 4), dtype=np.uint8)
+    arr[:, :, 3] = 255
+    img = Image.fromarray(arr, "RGBA")
+    entropy = compute_entropy(img)
+    assert entropy > 5.0, "Random noise should have high entropy"
+
+
+def test_entropy_labeler_vector_classification() -> None:
+    """Test that solid colors are classified as vectors."""
+    elements = [
+        create_solid_color_element(1, (50, 50), (255, 0, 0, 255)),
+        create_solid_color_element(2, (50, 50), (0, 255, 0, 255)),
+    ]
+
+    labeler = EntropyLabeler(threshold=5.0)
+    result = labeler.classify(elements)
+
+    assert len(result) == 2
+    assert all(elem["type"] == "vector" for elem in result), "Solid colors should be classified as vector"
+
+
+def test_entropy_labeler_image_classification() -> None:
+    """Test that high-entropy content is classified as images."""
+    elements = [
+        create_noise_element(1, (50, 50)),
+        create_noise_element(2, (50, 50)),
+    ]
+
+    labeler = EntropyLabeler(threshold=5.0)
+    result = labeler.classify(elements)
+
+    assert len(result) == 2
+    assert all(elem["type"] == "image" for elem in result), "Noise should be classified as image"
+
+
+def test_entropy_labeler_preserves_text() -> None:
+    """Test that text elements are not modified."""
+    img = Image.new("RGBA", (50, 50), (255, 0, 0, 255))
+    elements = [Element(id=1, type="text", image=img, box=BoundingBox(x_min=0, y_min=0, x_max=50, y_max=50))]
+
+    labeler = EntropyLabeler(threshold=5.0)
+    result = labeler.classify(elements)
+
+    assert result[0]["type"] == "text", "Text elements should not be modified"
+
+
+def test_gradient_aware_labeler_gradient_detection() -> None:
+    """Test that gradients are detected and kept as images."""
+    elements = [create_gradient_element(1, (100, 100))]
+
+    labeler = GradientAwareLabeler(entropy_threshold=5.0, gradient_threshold=0.3)
+    result = labeler.classify(elements)
+
+    assert result[0]["type"] == "image", "Gradients should be kept as raster images"
+
+
+def test_gradient_aware_labeler_solid_vector() -> None:
+    """Test that solid colors are classified as vectors."""
+    elements = [create_solid_color_element(1, (50, 50), (255, 0, 0, 255))]
+
+    labeler = GradientAwareLabeler(entropy_threshold=5.0, gradient_threshold=0.3)
+    result = labeler.classify(elements)
+
+    assert result[0]["type"] == "vector", "Solid colors without gradients should be vectors"
+
+
+def test_gradient_aware_labeler_noise_image() -> None:
+    """Test that noisy images remain as images."""
+    elements = [create_noise_element(1, (50, 50))]
+
+    labeler = GradientAwareLabeler(entropy_threshold=5.0, gradient_threshold=0.3)
+    result = labeler.classify(elements)
+
+    assert result[0]["type"] == "image", "Noisy content should remain as image"
+
+
+def test_gradient_aware_labeler_custom_thresholds() -> None:
+    """Test labeler with custom thresholds."""
+    elements = [
+        create_solid_color_element(1, (50, 50), (255, 0, 0, 255)),
+        create_gradient_element(2, (100, 100)),
+    ]
+
+    # Very strict gradient threshold
+    labeler = GradientAwareLabeler(entropy_threshold=5.0, gradient_threshold=1.0)
+    result = labeler.classify(elements)
+
+    assert result[0]["type"] == "vector", "Solid color should be vector"
+    # Gradient might not be detected with high threshold, but should still work
+
+
+def test_classification_preserves_element_structure() -> None:
+    """Test that classification preserves all element fields."""
+    img = Image.new("RGBA", (50, 50), (255, 0, 0, 255))
+    original = Element(id=42, type="image", image=img, box=BoundingBox(x_min=10, y_min=20, x_max=60, y_max=70))
+
+    labeler = EntropyLabeler()
+    result = labeler.classify([original])
+
+    assert result[0]["id"] == 42
+    assert result[0]["image"].size == (50, 50)
+    assert result[0]["box"]["x_min"] == 10
+    assert result[0]["box"]["y_min"] == 20
+    assert result[0]["box"]["x_max"] == 60
+    assert result[0]["box"]["y_max"] == 70

--- a/tests/export/__init__.py
+++ b/tests/export/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for export module."""

--- a/tests/export/test_psd_export.py
+++ b/tests/export/test_psd_export.py
@@ -1,0 +1,122 @@
+"""Tests for PSD export functionality."""
+
+from PIL import Image, ImageDraw
+
+from layerd.export import PSDBuilder
+from layerd.types import BoundingBox, Element
+
+
+def create_test_element(elem_id: int, elem_type: str, bbox: tuple[int, int, int, int]) -> Element:
+    """Create a test element with a simple colored rectangle.
+
+    Args:
+        elem_id: Element ID
+        elem_type: Element type ("text", "image", or "vector")
+        bbox: Bounding box as (x_min, y_min, x_max, y_max)
+
+    Returns:
+        Test Element with RGBA image
+    """
+    x_min, y_min, x_max, y_max = bbox
+    width = x_max - x_min
+    height = y_max - y_min
+
+    # Create simple colored image
+    colors = {"text": (255, 100, 100, 255), "image": (100, 255, 100, 255), "vector": (100, 100, 255, 255)}
+    color = colors.get(elem_type, (128, 128, 128, 255))
+
+    img = Image.new("RGBA", (width, height), color)
+    draw = ImageDraw.Draw(img)
+    draw.rectangle([0, 0, width - 1, height - 1], outline=(0, 0, 0, 255), width=2)
+
+    return Element(
+        id=elem_id,
+        type=elem_type,
+        image=img,
+        box=BoundingBox(x_min=x_min, y_min=y_min, x_max=x_max, y_max=y_max),
+    )
+
+
+def test_psd_builder_basic() -> None:
+    """Test basic PSD export."""
+    elements = [
+        create_test_element(1, "text", (10, 10, 110, 60)),
+        create_test_element(2, "vector", (150, 50, 250, 150)),
+    ]
+
+    builder = PSDBuilder()
+    psd_bytes = builder(elements, canvas_size=(300, 200))
+
+    # Verify we got bytes
+    assert isinstance(psd_bytes, bytes)
+    assert len(psd_bytes) > 0
+
+    # Verify PSD header signature (8BPS)
+    assert psd_bytes[:4] == b"8BPS"
+
+
+def test_psd_builder_compression_options() -> None:
+    """Test PSD export with different compression options."""
+    elements = [create_test_element(1, "text", (20, 20, 120, 70))]
+
+    # Test different compression methods
+    for compression in ["raw", "rle", "zip"]:
+        builder = PSDBuilder(compression=compression)
+        psd_bytes = builder(elements, canvas_size=(200, 100))
+
+        assert isinstance(psd_bytes, bytes)
+        assert len(psd_bytes) > 0
+        assert psd_bytes[:4] == b"8BPS"
+
+
+def test_psd_builder_color_depth() -> None:
+    """Test PSD export with 8-bit color depth."""
+    elements = [create_test_element(1, "image", (20, 20, 120, 70))]
+
+    # Test 8-bit depth (default and most common)
+    # Note: 16 and 32-bit depths have issues with psd-tools library
+    builder = PSDBuilder(color_depth=8)
+    psd_bytes = builder(elements, canvas_size=(200, 100))
+
+    assert isinstance(psd_bytes, bytes)
+    assert len(psd_bytes) > 0
+    assert psd_bytes[:4] == b"8BPS"
+
+
+def test_psd_builder_callable() -> None:
+    """Test that PSDBuilder can be called as a function."""
+    elements = [create_test_element(1, "text", (10, 10, 110, 60))]
+
+    builder = PSDBuilder()
+
+    # Test both calling methods
+    psd1 = builder.export(elements, canvas_size=(200, 100))
+    psd2 = builder(elements, canvas_size=(200, 100))
+
+    assert psd1 == psd2
+
+
+def test_psd_builder_multiple_layers() -> None:
+    """Test PSD export with multiple layers."""
+    elements = [
+        create_test_element(1, "text", (10, 10, 100, 50)),
+        create_test_element(2, "vector", (120, 20, 220, 120)),
+        create_test_element(3, "image", (50, 150, 150, 250)),
+    ]
+
+    builder = PSDBuilder()
+    psd_bytes = builder(elements, canvas_size=(300, 300))
+
+    assert isinstance(psd_bytes, bytes)
+    assert len(psd_bytes) > 0
+    assert psd_bytes[:4] == b"8BPS"
+
+
+def test_psd_builder_empty_elements() -> None:
+    """Test PSD export with no elements."""
+    builder = PSDBuilder()
+    psd_bytes = builder([], canvas_size=(300, 200))
+
+    assert isinstance(psd_bytes, bytes)
+    assert len(psd_bytes) > 0
+    assert psd_bytes[:4] == b"8BPS"

--- a/tests/export/test_svg_export.py
+++ b/tests/export/test_svg_export.py
@@ -1,0 +1,172 @@
+"""Tests for SVG export functionality."""
+
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+
+from layerd.export import SVGBuilder, SVGParser
+from layerd.types import BoundingBox, Element
+
+
+def create_test_element(elem_id: int, elem_type: str, bbox: tuple[int, int, int, int]) -> Element:
+    """Create a test element with a simple colored rectangle.
+
+    Args:
+        elem_id: Element ID
+        elem_type: Element type ("text", "image", or "vector")
+        bbox: Bounding box as (x_min, y_min, x_max, y_max)
+
+    Returns:
+        Test Element with RGBA image
+    """
+    x_min, y_min, x_max, y_max = bbox
+    width = x_max - x_min
+    height = y_max - y_min
+
+    # Create simple colored image
+    img = Image.new("RGBA", (width, height), (255, 100, 100, 255))
+    draw = ImageDraw.Draw(img)
+    draw.rectangle([0, 0, width - 1, height - 1], outline=(0, 0, 0, 255), width=2)
+
+    return Element(
+        id=elem_id,
+        type=elem_type,
+        image=img,
+        box=BoundingBox(x_min=x_min, y_min=y_min, x_max=x_max, y_max=y_max),
+    )
+
+
+def test_svg_builder_base64() -> None:
+    """Test SVG export with base64 image embedding."""
+    elements = [
+        create_test_element(1, "text", (10, 10, 110, 60)),
+        create_test_element(2, "vector", (150, 50, 250, 150)),
+    ]
+
+    builder = SVGBuilder(image_mode="base64")
+    svg_content = builder(elements, canvas_size=(300, 200))
+
+    # Verify SVG structure
+    assert "<svg" in svg_content
+    assert 'width="300"' in svg_content
+    assert 'height="200"' in svg_content
+    assert "</svg>" in svg_content
+
+    # Verify base64 embedding
+    assert "data:image/png;base64," in svg_content
+
+    # Verify metadata
+    assert 'data-type="text"' in svg_content
+    assert 'data-type="vector"' in svg_content
+    assert 'data-id="1"' in svg_content
+    assert 'data-id="2"' in svg_content
+
+
+def test_svg_builder_external_images(tmp_path: Path) -> None:
+    """Test SVG export with external image files."""
+    elements = [
+        create_test_element(1, "text", (20, 20, 120, 70)),
+        create_test_element(2, "image", (150, 50, 250, 150)),
+    ]
+
+    image_dir = tmp_path / "images"
+    builder = SVGBuilder(image_mode="external", image_dir=str(image_dir))
+    svg_content = builder(elements, canvas_size=(300, 200))
+
+    # Verify SVG structure
+    assert "<svg" in svg_content
+    assert "</svg>" in svg_content
+
+    # Should NOT have base64 data
+    assert "data:image/png;base64," not in svg_content
+
+    # Should have external references
+    assert "./images/" in svg_content
+
+    # Check that image files were created
+    assert (image_dir / "1_text.png").exists()
+    assert (image_dir / "2_image.png").exists()
+
+
+def test_svg_parser_base64() -> None:
+    """Test SVG parsing with base64 images."""
+    # Create elements
+    original_elements = [
+        create_test_element(1, "text", (10, 10, 110, 60)),
+        create_test_element(2, "vector", (150, 50, 250, 150)),
+    ]
+
+    # Export to SVG
+    builder = SVGBuilder(image_mode="base64")
+    svg_content = builder(original_elements, canvas_size=(300, 200))
+
+    # Parse back
+    parser = SVGParser()
+    parsed_elements = parser(svg_content)
+
+    # Verify round-trip
+    assert len(parsed_elements) == len(original_elements)
+
+    for orig, parsed in zip(original_elements, parsed_elements):
+        assert orig["id"] == parsed["id"]
+        assert orig["type"] == parsed["type"]
+        assert orig["box"] == parsed["box"]
+        assert orig["image"].size == parsed["image"].size
+
+
+def test_svg_parser_external_images(tmp_path: Path) -> None:
+    """Test SVG parsing with external image files."""
+    # Create elements
+    original_elements = [
+        create_test_element(1, "text", (20, 20, 120, 70)),
+        create_test_element(2, "image", (150, 50, 250, 150)),
+    ]
+
+    # Export to SVG with external images
+    image_dir = tmp_path / "images"
+    builder = SVGBuilder(image_mode="external", image_dir=str(image_dir))
+    svg_content = builder(original_elements, canvas_size=(300, 200))
+
+    # Save SVG file
+    svg_path = tmp_path / "test.svg"
+    with open(svg_path, "w") as f:
+        f.write(svg_content)
+
+    # Parse back
+    parser = SVGParser()
+    parsed_elements = parser(svg_content, svg_path=str(svg_path))
+
+    # Verify round-trip
+    assert len(parsed_elements) == len(original_elements)
+
+    for orig, parsed in zip(original_elements, parsed_elements):
+        assert orig["id"] == parsed["id"]
+        assert orig["type"] == parsed["type"]
+        assert orig["box"] == parsed["box"]
+        assert orig["image"].size == parsed["image"].size
+
+
+def test_svg_builder_callable() -> None:
+    """Test that SVGBuilder can be called as a function."""
+    elements = [create_test_element(1, "text", (10, 10, 110, 60))]
+
+    builder = SVGBuilder()
+
+    # Test both calling methods
+    svg1 = builder.export(elements, canvas_size=(200, 100))
+    svg2 = builder(elements, canvas_size=(200, 100))
+
+    assert svg1 == svg2
+
+
+def test_svg_builder_empty_elements() -> None:
+    """Test SVG export with no elements."""
+    builder = SVGBuilder()
+    svg_content = builder([], canvas_size=(300, 200))
+
+    assert "<svg" in svg_content
+    assert 'width="300"' in svg_content
+    assert 'height="200"' in svg_content
+    assert "</svg>" in svg_content
+    # Should have no image elements
+    assert "<image" not in svg_content

--- a/tests/postprocess/__init__.py
+++ b/tests/postprocess/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for postprocess module."""

--- a/tests/postprocess/test_organizer.py
+++ b/tests/postprocess/test_organizer.py
@@ -1,0 +1,192 @@
+"""Tests for LayerOrganizer."""
+
+from PIL import Image, ImageDraw
+
+from layerd.postprocess import LayerOrganizer
+from layerd.types import BoundingBox
+
+
+def create_dummy_layer(width: int, height: int, shapes: list[tuple[str, tuple[int, int, int, int]]]) -> Image.Image:
+    """Create dummy RGBA layer with shapes.
+
+    Args:
+        width: Image width
+        height: Image height
+        shapes: List of (shape_type, bbox) tuples
+                shape_type: "rect" or "circle"
+                bbox: (x_min, y_min, x_max, y_max)
+
+    Returns:
+        RGBA PIL Image
+    """
+    img = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+
+    for shape_type, bbox in shapes:
+        if shape_type == "rect":
+            draw.rectangle(bbox, fill=(255, 100, 100, 255))
+        elif shape_type == "circle":
+            draw.ellipse(bbox, fill=(100, 100, 255, 255))
+
+    return img
+
+
+def test_organizer_basic_no_ocr() -> None:
+    """Test basic LayerOrganizer functionality without OCR."""
+    # Create dummy layers
+    layer1 = create_dummy_layer(
+        512,
+        512,
+        [
+            ("rect", (50, 50, 150, 100)),  # Shape 1
+            ("circle", (300, 300, 400, 400)),  # Shape 2
+        ],
+    )
+    layer2 = create_dummy_layer(512, 512, [("rect", (200, 200, 300, 250))])  # Shape 3
+
+    layers = [layer1, layer2]
+
+    # Run organizer without OCR
+    organizer = LayerOrganizer()
+    elements = organizer.organize(layers)
+
+    # Basic assertions
+    assert len(elements) > 0, "Should return at least one element"
+    assert all("id" in elem for elem in elements), "All elements should have 'id'"
+    assert all("type" in elem for elem in elements), "All elements should have 'type'"
+    assert all("image" in elem for elem in elements), "All elements should have 'image'"
+    assert all("box" in elem for elem in elements), "All elements should have 'box'"
+
+    # Without OCR, all elements should be "image" type
+    types = [elem["type"] for elem in elements]
+    assert all(t == "image" for t in types), "All elements should be 'image' type without OCR"
+
+
+def test_organizer_with_ocr() -> None:
+    """Test LayerOrganizer with OCR result."""
+    # Create layer with text region
+    layer = create_dummy_layer(256, 256, [("rect", (50, 50, 150, 100))])
+
+    # Create OCR result that matches the rect
+    ocr_result = {
+        "image_size": (256, 256),
+        "blocks": [
+            {
+                "text": "Sample text",
+                "bbox": BoundingBox(x_min=50, y_min=50, x_max=150, y_max=100),
+            }
+        ],
+    }
+
+    organizer = LayerOrganizer(overlap_threshold=0.9)
+    elements = organizer.organize([layer], ocr_result)
+
+    # Should have exactly one text element
+    text_elements = [e for e in elements if e["type"] == "text"]
+    assert len(text_elements) == 1, f"Should have exactly one text element, got {len(text_elements)}"
+
+    # Verify the cropped image is RGBA
+    assert text_elements[0]["image"].mode == "RGBA", "Text element image should be RGBA"
+
+
+def test_organizer_no_ocr_match() -> None:
+    """Test when OCR doesn't match any layer regions."""
+    # Create layer with shape
+    layer = create_dummy_layer(256, 256, [("circle", (50, 50, 150, 150))])
+
+    # Create OCR result far from the shape
+    ocr_result = {
+        "image_size": (256, 256),
+        "blocks": [
+            {
+                "text": "Sample text",
+                "bbox": BoundingBox(x_min=200, y_min=200, x_max=250, y_max=250),
+            }
+        ],
+    }
+
+    organizer = LayerOrganizer(overlap_threshold=0.9)
+    elements = organizer.organize([layer], ocr_result)
+
+    # All elements should be non-text type (image)
+    assert all(e["type"] == "image" for e in elements), "All elements should be 'image' type"
+
+
+def test_organizer_output_format() -> None:
+    """Test output format consistency."""
+    layer = create_dummy_layer(128, 128, [("rect", (20, 20, 60, 60))])
+
+    organizer = LayerOrganizer()
+    elements = organizer.organize([layer])
+
+    for elem in elements:
+        # Check Element structure
+        assert isinstance(elem["id"], int), f"Element id should be int, got {type(elem['id'])}"
+        assert elem["type"] in ["text", "image", "vector"], f"Invalid element type: {elem['type']}"
+        assert isinstance(elem["image"], Image.Image), "Element image should be PIL Image"
+        assert "x_min" in elem["box"], "Element box should have 'x_min'"
+        assert "y_min" in elem["box"], "Element box should have 'y_min'"
+        assert "x_max" in elem["box"], "Element box should have 'x_max'"
+        assert "y_max" in elem["box"], "Element box should have 'y_max'"
+
+        # Check bounding box validity
+        box = elem["box"]
+        assert box["x_min"] < box["x_max"], "x_min should be less than x_max"
+        assert box["y_min"] < box["y_max"], "y_min should be less than y_max"
+
+
+def test_organizer_callable() -> None:
+    """Test that LayerOrganizer can be called as a function."""
+    layer = create_dummy_layer(128, 128, [("rect", (20, 20, 60, 60))])
+
+    organizer = LayerOrganizer()
+
+    # Test both calling methods
+    elements1 = organizer.organize([layer])
+    elements2 = organizer([layer])
+
+    assert len(elements1) == len(elements2)
+
+
+def test_organizer_empty_layers() -> None:
+    """Test organizer with fully transparent layers."""
+    # Create completely transparent layer
+    layer = Image.new("RGBA", (100, 100), (0, 0, 0, 0))
+
+    organizer = LayerOrganizer()
+    elements = organizer.organize([layer])
+
+    # Should return empty list or handle gracefully
+    assert isinstance(elements, list)
+
+
+def test_organizer_with_polygon_ocr() -> None:
+    """Test LayerOrganizer with polygon-based OCR result."""
+    # Create layer with shape
+    layer = create_dummy_layer(256, 256, [("rect", (50, 50, 150, 100))])
+
+    # Create OCR result with polygon
+    ocr_result = {
+        "image_size": (256, 256),
+        "blocks": [
+            {
+                "text": "Sample text",
+                "bbox": BoundingBox(x_min=50, y_min=50, x_max=150, y_max=100),
+                "polygon": [
+                    {"x": 50, "y": 50},
+                    {"x": 150, "y": 50},
+                    {"x": 150, "y": 100},
+                    {"x": 50, "y": 100},
+                ],
+            }
+        ],
+    }
+
+    organizer = LayerOrganizer(overlap_threshold=0.9)
+    elements = organizer.organize([layer], ocr_result)
+
+    # Should have at least one element
+    assert len(elements) > 0
+    # Should have text element due to polygon match
+    text_elements = [e for e in elements if e["type"] == "text"]
+    assert len(text_elements) >= 1

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,373 @@
+"""Unit tests for LayerDPipeline with mocked components."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+from layerd.classification import EntropyLabeler
+from layerd.pipeline import LayerDPipeline, PipelineResult
+from layerd.types import BoundingBox, Element
+
+
+def create_dummy_image(width: int = 512, height: int = 512) -> Image.Image:
+    """Create a dummy RGB image for testing."""
+    return Image.new("RGB", (width, height), color=(255, 255, 255))
+
+
+def create_dummy_layer(width: int = 512, height: int = 512) -> Image.Image:
+    """Create a dummy RGBA layer for testing."""
+    return Image.new("RGBA", (width, height), color=(255, 100, 100, 255))
+
+
+def create_dummy_element() -> Element:
+    """Create a dummy element."""
+    return Element(
+        id=0,
+        type="image",
+        image=create_dummy_layer(),
+        box=BoundingBox(x_min=50, y_min=50, x_max=200, y_max=100),
+    )
+
+
+class TestPipelineInitialization:
+    """Test LayerDPipeline initialization."""
+
+    def test_init_default_parameters(self) -> None:
+        """Test initialization with default parameters."""
+        pipeline = LayerDPipeline()
+        assert pipeline.device == "cpu"
+        assert pipeline.overlap_threshold == 0.9
+        assert isinstance(pipeline.labeler, EntropyLabeler)
+        assert pipeline.labeler.threshold == 5.0
+
+    def test_init_custom_layerd_parameters(self) -> None:
+        """Test initialization with custom LayerD parameters."""
+        pipeline = LayerDPipeline(
+            matting_process_size=(512, 512),
+            use_unblend=False,
+            bg_refine=False,
+            fg_refine=False,
+        )
+        assert pipeline.layerd is not None
+
+    def test_init_custom_organizer_parameters(self) -> None:
+        """Test initialization with custom LayerOrganizer parameters."""
+        pipeline = LayerDPipeline(
+            overlap_threshold=0.7,
+            labeler=None,  # Disable classification
+        )
+        assert pipeline.overlap_threshold == 0.7
+        assert pipeline.labeler is None
+
+    def test_init_custom_labeler(self) -> None:
+        """Test initialization with custom labeler threshold."""
+        pipeline = LayerDPipeline(labeler_threshold=3.0)
+        assert isinstance(pipeline.labeler, EntropyLabeler)
+        assert pipeline.labeler.threshold == 3.0
+
+
+class TestPipelineExecution:
+    """Test pipeline execution."""
+
+    @patch("layerd.pipeline.LayerD")
+    @patch("layerd.pipeline.LayerOrganizer")
+    def test_pipeline_basic_execution(
+        self,
+        mock_organizer_cls: MagicMock,
+        mock_layerd_cls: MagicMock,
+    ) -> None:
+        """Test complete pipeline execution."""
+        # Setup mocks
+        mock_layerd = MagicMock()
+        mock_layerd.decompose.return_value = [create_dummy_layer(), create_dummy_layer()]
+        mock_layerd_cls.return_value = mock_layerd
+
+        mock_organizer = MagicMock()
+        mock_organizer.organize.return_value = [create_dummy_element()]
+        mock_organizer_cls.return_value = mock_organizer
+
+        # Create pipeline and run
+        pipeline = LayerDPipeline()
+        image = create_dummy_image()
+        result = pipeline(image, max_iterations=3)
+
+        # Verify result structure
+        assert isinstance(result, PipelineResult)
+        assert len(result.layers) == 2
+        assert len(result.elements) == 1
+        assert result.ocr_result is None  # Phase 2: no OCR
+        assert result.canvas_size == (512, 512)
+
+        # Verify method calls
+        mock_layerd.decompose.assert_called_once_with(image, max_iterations=3)
+        mock_organizer.organize.assert_called_once()
+
+    @patch("layerd.pipeline.LayerD")
+    @patch("layerd.pipeline.LayerOrganizer")
+    def test_pipeline_layers_are_rgba(
+        self,
+        mock_organizer_cls: MagicMock,
+        mock_layerd_cls: MagicMock,
+    ) -> None:
+        """Test that pipeline returns RGBA layers."""
+        # Setup mocks
+        mock_layerd = MagicMock()
+        layer1 = create_dummy_layer()
+        layer2 = create_dummy_layer()
+        mock_layerd.decompose.return_value = [layer1, layer2]
+        mock_layerd_cls.return_value = mock_layerd
+
+        mock_organizer = MagicMock()
+        mock_organizer.organize.return_value = [create_dummy_element()]
+        mock_organizer_cls.return_value = mock_organizer
+
+        # Run pipeline
+        pipeline = LayerDPipeline()
+        result = pipeline(create_dummy_image())
+
+        # Verify layers
+        assert all(layer.mode == "RGBA" for layer in result.layers)
+
+
+class TestDeviceSwitching:
+    """Test device switching behavior."""
+
+    @patch("layerd.pipeline.LayerD")
+    def test_device_switching(self, mock_layerd_cls: MagicMock) -> None:
+        """Test device switching."""
+        mock_layerd = MagicMock()
+        mock_layerd.to.return_value = mock_layerd
+        mock_layerd_cls.return_value = mock_layerd
+
+        pipeline = LayerDPipeline(device="cpu")
+        assert pipeline.device == "cpu"
+
+        # Switch device
+        result = pipeline.to("cuda")
+        assert result is pipeline  # Returns self
+        assert pipeline.device == "cuda"
+        mock_layerd.to.assert_called_once_with("cuda")
+
+
+class TestErrorHandling:
+    """Test error handling in pipeline."""
+
+    @patch("layerd.pipeline.LayerD")
+    def test_layerd_decomposition_error(self, mock_layerd_cls: MagicMock) -> None:
+        """Test error handling when LayerD decomposition fails."""
+        mock_layerd = MagicMock()
+        mock_layerd.decompose.side_effect = RuntimeError("Decomposition failed")
+        mock_layerd_cls.return_value = mock_layerd
+
+        pipeline = LayerDPipeline()
+
+        with pytest.raises(RuntimeError, match="LayerD decomposition failed"):
+            pipeline(create_dummy_image())
+
+    @patch("layerd.pipeline.LayerD")
+    @patch("layerd.pipeline.LayerOrganizer")
+    def test_organizer_error(
+        self,
+        mock_organizer_cls: MagicMock,
+        mock_layerd_cls: MagicMock,
+    ) -> None:
+        """Test error handling when LayerOrganizer fails."""
+        mock_layerd = MagicMock()
+        mock_layerd.decompose.return_value = [create_dummy_layer()]
+        mock_layerd_cls.return_value = mock_layerd
+
+        mock_organizer = MagicMock()
+        mock_organizer.organize.side_effect = RuntimeError("Organizer failed")
+        mock_organizer_cls.return_value = mock_organizer
+
+        pipeline = LayerDPipeline()
+
+        with pytest.raises(RuntimeError, match="Layer organization failed"):
+            pipeline(create_dummy_image())
+
+
+class TestPipelineResult:
+    """Test PipelineResult model."""
+
+    def test_pipeline_result_structure(self) -> None:
+        """Test PipelineResult structure and types."""
+        result = PipelineResult(
+            elements=[create_dummy_element()],
+            layers=[create_dummy_layer()],
+            ocr_result=None,
+            canvas_size=(512, 512),
+        )
+
+        assert len(result.elements) == 1
+        assert len(result.layers) == 1
+        assert result.ocr_result is None
+        assert result.canvas_size == (512, 512)
+
+    @patch("layerd.pipeline.SVGBuilder")
+    def test_to_svg_base64(self, mock_svg_builder: MagicMock) -> None:
+        """Test SVG export with base64 mode."""
+        mock_builder = MagicMock()
+        mock_builder.return_value = "<svg>test</svg>"
+        mock_svg_builder.return_value = mock_builder
+
+        result = PipelineResult(
+            elements=[create_dummy_element()],
+            layers=[create_dummy_layer()],
+            ocr_result=None,
+            canvas_size=(512, 512),
+        )
+
+        svg = result.to_svg()
+        assert svg == "<svg>test</svg>"
+        mock_svg_builder.assert_called_once_with(image_mode="base64", image_dir=None)
+
+    @patch("layerd.pipeline.SVGBuilder")
+    def test_to_svg_external(self, mock_svg_builder: MagicMock) -> None:
+        """Test SVG export with external images."""
+        mock_builder = MagicMock()
+        mock_builder.return_value = "<svg>test</svg>"
+        mock_svg_builder.return_value = mock_builder
+
+        result = PipelineResult(
+            elements=[create_dummy_element()],
+            layers=[create_dummy_layer()],
+            ocr_result=None,
+            canvas_size=(512, 512),
+        )
+
+        svg = result.to_svg(image_mode="external", image_dir="./images")
+        assert svg == "<svg>test</svg>"
+        mock_svg_builder.assert_called_once_with(image_mode="external", image_dir="./images")
+
+    def test_to_svg_external_without_dir_raises(self) -> None:
+        """Test that external mode without image_dir raises ValueError."""
+        result = PipelineResult(
+            elements=[create_dummy_element()],
+            layers=[create_dummy_layer()],
+            ocr_result=None,
+            canvas_size=(512, 512),
+        )
+
+        with pytest.raises(ValueError, match="image_dir required"):
+            result.to_svg(image_mode="external")
+
+    @patch("layerd.pipeline.build_exporter")
+    def test_to_psd(self, mock_build_exporter: MagicMock) -> None:
+        """Test PSD export."""
+        mock_builder = MagicMock()
+        mock_builder.return_value = b"PSD data"
+        mock_build_exporter.return_value = mock_builder
+
+        result = PipelineResult(
+            elements=[create_dummy_element()],
+            layers=[create_dummy_layer()],
+            ocr_result=None,
+            canvas_size=(512, 512),
+        )
+
+        psd_bytes = result.to_psd()
+        assert psd_bytes == b"PSD data"
+        mock_build_exporter.assert_called_once_with("psd", compression="rle", color_depth=8)
+
+    @patch("layerd.pipeline.build_exporter")
+    def test_to_psd_custom_options(self, mock_build_exporter: MagicMock) -> None:
+        """Test PSD export with custom options."""
+        mock_builder = MagicMock()
+        mock_builder.return_value = b"PSD data"
+        mock_build_exporter.return_value = mock_builder
+
+        result = PipelineResult(
+            elements=[create_dummy_element()],
+            layers=[create_dummy_layer()],
+            ocr_result=None,
+            canvas_size=(512, 512),
+        )
+
+        psd_bytes = result.to_psd(compression="zip", color_depth=16)
+        assert psd_bytes == b"PSD data"
+        mock_build_exporter.assert_called_once_with("psd", compression="zip", color_depth=16)
+
+    @patch("layerd.pipeline.Path.mkdir")
+    @patch("builtins.open", create=True)
+    @patch("layerd.pipeline.SVGBuilder")
+    def test_save_svg_autodetect(
+        self,
+        mock_svg_builder: MagicMock,
+        mock_open: MagicMock,
+        mock_mkdir: MagicMock,
+    ) -> None:
+        """Test save with auto-detected SVG format."""
+        mock_builder = MagicMock()
+        mock_builder.return_value = "<svg>test</svg>"
+        mock_svg_builder.return_value = mock_builder
+
+        result = PipelineResult(
+            elements=[create_dummy_element()],
+            layers=[create_dummy_layer()],
+            ocr_result=None,
+            canvas_size=(512, 512),
+        )
+
+        result.save("output.svg")
+        mock_open.assert_called_once_with("output.svg", "w")
+
+    @patch("layerd.pipeline.Path.mkdir")
+    @patch("builtins.open", create=True)
+    @patch("layerd.pipeline.build_exporter")
+    def test_save_psd_autodetect(
+        self,
+        mock_build_exporter: MagicMock,
+        mock_open: MagicMock,
+        mock_mkdir: MagicMock,
+    ) -> None:
+        """Test save with auto-detected PSD format."""
+        mock_builder = MagicMock()
+        mock_builder.return_value = b"PSD data"
+        mock_build_exporter.return_value = mock_builder
+
+        result = PipelineResult(
+            elements=[create_dummy_element()],
+            layers=[create_dummy_layer()],
+            ocr_result=None,
+            canvas_size=(512, 512),
+        )
+
+        result.save("output.psd")
+        mock_open.assert_called_once_with("output.psd", "wb")
+
+    def test_save_unknown_extension_raises(self) -> None:
+        """Test that unknown extension raises ValueError."""
+        result = PipelineResult(
+            elements=[create_dummy_element()],
+            layers=[create_dummy_layer()],
+            ocr_result=None,
+            canvas_size=(512, 512),
+        )
+
+        with pytest.raises(ValueError, match="Cannot determine format"):
+            result.save("output.txt")
+
+    @patch("layerd.pipeline.Path.mkdir")
+    @patch("builtins.open", create=True)
+    @patch("layerd.pipeline.SVGBuilder")
+    def test_save_explicit_format(
+        self,
+        mock_svg_builder: MagicMock,
+        mock_open: MagicMock,
+        mock_mkdir: MagicMock,
+    ) -> None:
+        """Test save with explicit format parameter."""
+        mock_builder = MagicMock()
+        mock_builder.return_value = "<svg>test</svg>"
+        mock_svg_builder.return_value = mock_builder
+
+        result = PipelineResult(
+            elements=[create_dummy_element()],
+            layers=[create_dummy_layer()],
+            ocr_result=None,
+            canvas_size=(512, 512),
+        )
+
+        result.save("output", format="svg")
+        mock_open.assert_called_once_with("output", "w")


### PR DESCRIPTION
This PR completes Phase 2 of the OSS migration, adding the following modules to the OSS package:

## What's Changed

### New Modules
- **Export module** (layerd.export)
  - SVGBuilder for SVG export with base64/external image modes
  - SVGParser for parsing SVG files back to elements
  - PSDBuilder for Photoshop export with RLE/ZIP compression
  - Factory function: build_exporter()

- **Postprocess module** (layerd.postprocess)
  - LayerOrganizer for extracting and organizing elements from layers
  - Supports overlap threshold and optional classification

- **Classification module** (layerd.classification)
  - ElementLabeler abstract base class
  - EntropyLabeler for entropy-based text/vector/image classification
  - GradientAwareLabeler with gradient detection

- **Pipeline module** (layerd.pipeline)
  - LayerDPipeline for end-to-end decomposition → organization → export
  - PipelineResult with to_svg(), to_psd(), and save() methods
  - Designed for future REST API server integration

### Dependencies Added
- psd-tools>=1.9.0 for PSD export
- pydantic>=2.5.2 for pipeline result models

### Testing
- 48 unit tests added (19 pipeline, 10 classification, 9 export, 10 postprocess)
- All tests passing with mocked components
- No slow tests (runs in <1 minute)

## Related Issues
Closes #81, #82, #83, #84 (Phase 2 issues)